### PR TITLE
Increase the duration of the high error rate polices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ For detailed information on this package, please refer to the [online documentat
 
 ## Release History
 
+* Increase the duration of the high error rate polices
 
 ### Version 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ For detailed information on this package, please refer to the [online documentat
 
 ## Release History
 
+### Version next
+
 * Increase the duration of the high error rate polices
 
 ### Version 1.5.0

--- a/policies/high_load_balancer_error_rate.json
+++ b/policies/high_load_balancer_error_rate.json
@@ -16,7 +16,7 @@
     ],
     "creatorEmail": "research@metricly.com",
     "description": "This policy will generate a Critical alert when there are more that 5% HTTP errors to the ALB/Target Group. You may wish to tune this threshold to better suit your environment.",
-    "duration": 300,
+    "duration": 600,
     "enabled": true,
     "name": "AWS ALB - High Load Balancer Error Rate",
     "scope": {

--- a/policies/high_target_group_error_rate.json
+++ b/policies/high_target_group_error_rate.json
@@ -16,7 +16,7 @@
     ],
     "creatorEmail": "research@metricly.com",
     "description": "This policy will generate a Critical alert when there are more that 5% HTTP errors to the Target Group. You may wish to tune this threshold to better suit your environment.",
-    "duration": 300,
+    "duration": 600,
     "enabled": true,
     "name": "AWS ALB - High Target Group Error Rate",
     "scope": {


### PR DESCRIPTION
Single cycle elevated error rates are not indicative of widespread errors and cause too much noise.