### PR TITLE
Added requests per second metric for Target Groups

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ### Version next
 
+* Added requests per second computed metric for Target Groups
+
 ### Version 1.7.0
 
 * Removed ALB healthy and unhealthy host count metric references

--- a/analyticConfigurations/computed_metric-aws.tag.json
+++ b/analyticConfigurations/computed_metric-aws.tag.json
@@ -74,7 +74,7 @@
           "fqn": "netuitive.aws.applicationelb.httpcodeerrorpercent",
           "name": "HTTP Error Percent"
         }
-      }, 
+      },
       {
         "match": "netuitive.aws.applicationelb.requestspersecond",
         "properties": {

--- a/analyticConfigurations/computed_metric-aws.tag.json
+++ b/analyticConfigurations/computed_metric-aws.tag.json
@@ -74,6 +74,16 @@
           "fqn": "netuitive.aws.applicationelb.httpcodeerrorpercent",
           "name": "HTTP Error Percent"
         }
+      }, 
+      {
+        "match": "netuitive.aws.applicationelb.requestspersecond",
+        "properties": {
+          "expressions": [
+            "${aws.applicationelb.requestcount}.actual / 300.0"
+          ],
+          "fqn": "netuitive.aws.applicationelb.requestspersecond",
+          "name": "Requests per Second"
+        }
       }
     ],
     "name": "AWS Target Group",

--- a/analyticConfigurations/metric_meta-aws.tag.json
+++ b/analyticConfigurations/metric_meta-aws.tag.json
@@ -45,6 +45,14 @@
           },
           "validMax": 100
         }
+      },
+      {
+        "match": "netuitive.aws.applicationelb.requestspersecond",
+        "properties": {
+          "tags": {
+            "unit": "ops"
+          }
+        }
       }
     ],
     "name": "AWS Target Group",


### PR DESCRIPTION
Requests per second are available for the ALB element type. They should be available for the Target Group type too.